### PR TITLE
Added click-and-hold QOL + react-script bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start start",
     "build": "react-scripts --openssl-legacy-provider start build",
-    "test": "react-scripts test",
+    "test": "react-scripts --openssl-legacy-provider start test",
     "eject": "react-scripts eject",
     "predeploy": "yarn run build",
     "deploy": "gh-pages -d build"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start start",
+    "build": "react-scripts --openssl-legacy-provider start build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "yarn run build",

--- a/src/components/ResourceGrid/Resource.js
+++ b/src/components/ResourceGrid/Resource.js
@@ -127,7 +127,7 @@ function ResourceGridItem({ Resource, index, craftStart, stopManualAutomation, s
 
   return (
     <ResourceWarp
-      onMouseDown={() => {
+      onClick={() => {
         switch (selectMode) {
           case "AutoToggle":
             toggleAuto(index);
@@ -141,7 +141,19 @@ function ResourceGridItem({ Resource, index, craftStart, stopManualAutomation, s
             }
         }
       }}
-      onMouseUp={()=>stopManualAutomation(index)}
+      onMouseDown={() => {
+        switch (selectMode) {
+          case "AutoToggle":
+            break;
+          case "Empower":
+            break;
+          default:
+            if (Resource && Object.keys(Resource.cost(save.have) ?? {}).length !== 0) {
+              craftStart(index);
+            }
+        }
+      }}
+      onMouseUp={() => stopManualAutomation(index)}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => {
         setHover(false);

--- a/src/components/ResourceGrid/Resource.js
+++ b/src/components/ResourceGrid/Resource.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { connect, useSelector } from "react-redux";
-import { craftStart, toggleAuto, resourceEmpower } from "../../modules/resources.js";
+import { craftStart, toggleAuto, resourceEmpower, stopManualAutomation } from "../../modules/resources.js";
 import styled, { keyframes } from 'styled-components';
 import notation from "../../util/notation.js";
 import { AutoConnected } from "../../data/resources.js";
@@ -112,7 +112,7 @@ const ResourceQuantity = styled.div`
  * @param {object} obj
  * @param {Resource} obj.data 
  */
-function ResourceGridItem({ Resource, index, craftStart, selectMode, toggleAuto, resourceEmpower, empowerLeft, cooldown }) {
+function ResourceGridItem({ Resource, index, craftStart, stopManualAutomation, selectMode, toggleAuto, resourceEmpower, empowerLeft, cooldown}) {
   const [isHover, setHover] = useState(false);
 
   const displayName = Resource ? Resource.name.replace(/(.)([A-Z])/g, `$1 $2`) : "";
@@ -127,7 +127,7 @@ function ResourceGridItem({ Resource, index, craftStart, selectMode, toggleAuto,
 
   return (
     <ResourceWarp
-      onClick={() => {
+      onMouseDown={() => {
         switch (selectMode) {
           case "AutoToggle":
             toggleAuto(index);
@@ -141,8 +141,11 @@ function ResourceGridItem({ Resource, index, craftStart, selectMode, toggleAuto,
             }
         }
       }}
+      onMouseUp={()=>stopManualAutomation(index)}
       onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
+      onMouseLeave={() => {
+        setHover(false);
+        stopManualAutomation(index)}}
       name={displayName}
       style={{
         backgroundColor: (save.unlocked && (save.automationDisabled || (selectMode === "AutoToggle" && displayResource))) ?
@@ -208,6 +211,7 @@ export default connect(
   {
     craftStart,
     toggleAuto,
-    resourceEmpower
+    resourceEmpower,
+    stopManualAutomation
   }
 )(React.memo(ResourceGridItem));

--- a/src/saveload.js
+++ b/src/saveload.js
@@ -15,6 +15,7 @@ export const DefaultSave = {
     unlocked: false,
     empower: 0,
     automationDisabled: false,
+    automationManual: false
   })),
   aside: {
     unlockStatus: {

--- a/src/tick.js
+++ b/src/tick.js
@@ -66,6 +66,10 @@ function Tick() {
       }
     }
 
+    // Continue to buy resources if click-and-held
+    if  (savefile.resources[order].automationManual && canBuy(Resource.name, savefile) !== 0)
+      store.dispatch(craftStart(order, false));
+  
     // Check craft end
     const lastTime = save.lastTime;
     if (lastTime !== null && Resource.craftTime !== undefined) {


### PR DESCRIPTION
I've wanted to be able to click-and-hold stuff for a while in this game, so I added it!

Added a "manualAutomation" flag & corresponding event that "automates" a resource after a OnMouseDown event. This flag is reset after a OnMouseUp event, or OnMouseLeave.

The only downside to this change is that it's impossible to "single click" extremely fast resources. I feel like this honestly isn't a problem, but I can also work on adding a "Toggle Hold Resource" button if this is unacceptable.

Thanks for the great game! Hope this pull request is OK!

(Additionally, the code wouldn't compile for me without adding the --openssl-legacy-provider parameter to package.json, so that's also included lol)